### PR TITLE
Use client extension for mod package files

### DIFF
--- a/src/main/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTask.java
+++ b/src/main/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTask.java
@@ -199,7 +199,7 @@ public class LegacyFeaturedModDeploymentTask implements Runnable {
   @SneakyThrows
   private Optional<StagedFile> packDirectory(Path directory, Short version, Path targetFolder, Map<String, Short> fileIds) {
     String directoryName = directory.getFileName().toString();
-    Path targetNxtFile = targetFolder.resolve(String.format("%s.%d.nxt", directoryName, version));
+    Path targetNxtFile = targetFolder.resolve(String.format("%s.%d.%s", directoryName, version, configuration.getModFilesExtension()));
     Path tmpNxtFile = toTmpFile(targetNxtFile);
 
     // E.g. "effects.nx2"

--- a/src/test/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTaskTest.java
+++ b/src/test/java/com/faforever/api/deployment/LegacyFeaturedModDeploymentTaskTest.java
@@ -142,7 +142,7 @@ public class LegacyFeaturedModDeploymentTaskTest {
 
     assertThat(files.get(1).getFileId(), is(2));
     assertThat(files.get(1).getMd5(), is(notNullValue()));
-    assertThat(files.get(1).getName(), is("someDir.1337.nxt"));
+    assertThat(files.get(1).getName(), is("someDir.1337.nx3"));
     assertThat(files.get(1).getVersion(), is((short) 1337));
 
     assertThat(Files.exists(targetFolder.getRoot().toPath().resolve("updates_faf_files/someDir.1337.nxt")), is(true));


### PR DESCRIPTION
Makes sure deployed mod package files do not conflict.

This is necessary for the legacy patcher, since it creates patch files using the scheme <old-filename>-<new-filename> and overwrites old files, and then delivers patch files that cannot be applied.

There are two other ways of getting rid of the bug:

* Update the legacy patcher to stop creating conflicting patch files
* Stop using the legacy patcher altogether

The latter option is the most preferable but cannot be done in the short term. The former action means updating a component that is slated to be eliminated in the medium term and that nobody understands.

Therefore, making this simple, low-risk change to the api is the best choice.