### PR TITLE
Feature/#81 legacy permission

### DIFF
--- a/src/inttest/java/com/faforever/api/data/Ladder1v1MapTest.java
+++ b/src/inttest/java/com/faforever/api/data/Ladder1v1MapTest.java
@@ -1,0 +1,52 @@
+package com.faforever.api.data;
+
+import com.faforever.api.AbstractIntegrationTest;
+import org.junit.Test;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Sql(executionPhase = ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:sql/prepDefaultUser.sql")
+@Sql(executionPhase = ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:sql/prepMapData.sql")
+@Sql(executionPhase = ExecutionPhase.AFTER_TEST_METHOD, scripts = "classpath:sql/cleanMapData.sql")
+public class Ladder1v1MapTest extends AbstractIntegrationTest {
+  private static final String NEW_LADDER_MAP_BODY = "{\"data\":{\"type\":\"ladder1v1Map\",\"relationships\":{\"mapVersion\":{\"data\":{\"type\":\"mapVersion\",\"id\":\"2\"}}}}}";
+
+  @Test
+  @WithUserDetails(AUTH_USER)
+  public void cannotCreateLadderMapAsUser() throws Exception {
+    mockMvc.perform(
+      post("/data/ladder1v1Map")
+        .content(NEW_LADDER_MAP_BODY)) // magic value from prepMapData.sql
+      .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithUserDetails(AUTH_MODERATOR)
+  public void canCreateLadderMapAsModerator() throws Exception {
+    mockMvc.perform(
+      post("/data/ladder1v1Map")
+        .content(NEW_LADDER_MAP_BODY)) // magic value from prepMapData.sql
+      .andExpect(status().isCreated());
+  }
+
+  @Test
+  @WithUserDetails(AUTH_USER)
+  public void cannotDeleteLadderMapAsUser() throws Exception {
+    mockMvc.perform(
+      delete("/data/ladder1v1Map/1")) // magic value from prepMapData.sql
+      .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithUserDetails(AUTH_MODERATOR)
+  public void canDeleteLadderMapAsModerator() throws Exception {
+    mockMvc.perform(
+      delete("/data/ladder1v1Map/1")) // magic value from prepMapData.sql
+      .andExpect(status().isNoContent());
+  }
+}

--- a/src/inttest/resources/config/application.yml
+++ b/src/inttest/resources/config/application.yml
@@ -27,6 +27,13 @@ security:
 faf-api:
   jwt:
     secret: banana
+  map:
+    target-directory: "build/cache/map/maps"
+    directory-preview-path-small: "build/cache/map_previews/small"
+    directory-preview-path-large: "build/cache/map_previews/large"
+    small-previews-url-format: "http://localhost/faf/vault/map_previews/small/%s"
+    large-previews-url-format: "http://localhost/faf/vault/map_previews/large/%s"
+    download-url-format: "http://localhost/faf/vault/maps/%s"
   clan:
     website-url-format: "http://example.com/%s"
   user:

--- a/src/inttest/resources/sql/cleanMapData.sql
+++ b/src/inttest/resources/sql/cleanMapData.sql
@@ -1,0 +1,2 @@
+DELETE FROM map_version;
+DELETE FROM map;

--- a/src/inttest/resources/sql/prepDefaultUser.sql
+++ b/src/inttest/resources/sql/prepDefaultUser.sql
@@ -1,14 +1,46 @@
+DELETE FROM unique_id_users;
+DELETE FROM uniqueid;
+DELETE FROM global_rating;
+DELETE FROM ladder1v1_rating;
+DELETE FROM uniqueid_exempt;
+DELETE FROM version_lobby;
+DELETE FROM friends_and_foes;
+DELETE FROM ladder_map;
+DELETE FROM map_version_review;
+DELETE FROM map_version;
+DELETE FROM `map`;
+DELETE FROM mod_version_review;
+DELETE FROM mod_version;
+DELETE FROM `mod`;
+DELETE FROM mod_stats;
 DELETE FROM oauth_clients;
+DELETE FROM updates_faf;
+DELETE FROM updates_faf_files;
+DELETE FROM avatars;
+DELETE FROM avatars_list;
+DELETE FROM ban_revoke;
+DELETE FROM ban;
+DELETE FROM clan_membership;
+DELETE FROM clan;
+DELETE FROM game_player_stats;
+DELETE FROM game_review;
+DELETE FROM game_stats;
+DELETE FROM game_featuredMods;
+DELETE FROM teamkills;
+DELETE FROM ladder_division_score;
+DELETE FROM ladder_division;
+DELETE FROM lobby_admin;
 DELETE FROM login;
 
 INSERT INTO oauth_clients (id, name, client_secret, client_type, redirect_uris, default_redirect_uri, default_scope)
 VALUES ('test', 'test', 'test', 'public', 'http://localhost', 'http://localhost',
         'read_events read_achievements upload_map upload_mod write_account_data');
 
-INSERT INTO login (id, login, email, password)
-VALUES (1, 'USER', 'user@faforever.com', '92b7b421992ef490f3b75898ec0e511f1a5c02422819d89719b20362b023ee4f');
-INSERT INTO login (id, login, email, password)
-VALUES (2, 'MODERATOR', 'moderator@faforever.com', '778ac5b81fa251b450f827846378739caee510c31b01cfa9d31822b88bed8441');
-INSERT INTO login (id, login, email, password)
-VALUES (3, 'ADMIN', 'admin@faforever.com', '835d6dc88b708bc646d6db82c853ef4182fabbd4a8de59c213f2b5ab3ae7d9be');
+INSERT INTO login (id, login, email, password) VALUES
+  (1, 'USER', 'user@faforever.com', '92b7b421992ef490f3b75898ec0e511f1a5c02422819d89719b20362b023ee4f'),
+  (2, 'MODERATOR', 'moderator@faforever.com', '778ac5b81fa251b450f827846378739caee510c31b01cfa9d31822b88bed8441'),
+  (3, 'ADMIN', 'admin@faforever.com', '835d6dc88b708bc646d6db82c853ef4182fabbd4a8de59c213f2b5ab3ae7d9be');
 
+INSERT INTO lobby_admin (user_id, `group`) VALUES
+  (2, 1),
+  (3, 2);

--- a/src/inttest/resources/sql/prepMapData.sql
+++ b/src/inttest/resources/sql/prepMapData.sql
@@ -1,0 +1,14 @@
+DELETE FROM ladder_map;
+DELETE FROM map_version;
+DELETE FROM map;
+
+INSERT INTO map (id, display_name, map_type, battle_type, author) VALUES
+  (1, 'SCMP_001', 'FFA', 'skirmish', 1),
+  (2, 'SCMP_002', 'FFA', 'skirmish', 1);
+
+INSERT INTO map_version (id, description, max_players, width, height, version, filename, hidden, map_id) VALUES
+  (1, 'SCMP 001', 8, 5, 5, 1, 'maps/scmp_001.v0001.zip', 0, 1),
+  (2, 'SCMP 002', 8, 5, 5, 1, 'maps/scmp_002.v0001.zip', 0, 2);
+
+INSERT INTO ladder_map (id, idmap) VALUES
+  (1, 1);

--- a/src/main/java/com/faforever/api/config/elide/ElideConfig.java
+++ b/src/main/java/com/faforever/api/config/elide/ElideConfig.java
@@ -9,10 +9,10 @@ import com.faforever.api.data.checks.IsReviewOwner;
 import com.faforever.api.data.checks.permission.HasBanRead;
 import com.faforever.api.data.checks.permission.HasBanUpdate;
 import com.faforever.api.data.checks.permission.HasLadder1v1Update;
+import com.faforever.api.security.ExtendedAuditLogger;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideSettingsBuilder;
-import com.yahoo.elide.audit.Slf4jLogger;
 import com.yahoo.elide.core.EntityDictionary;
 import com.yahoo.elide.core.filter.dialect.RSQLFilterDialect;
 import com.yahoo.elide.datastores.hibernate5.HibernateStore;
@@ -46,7 +46,7 @@ public class ElideConfig {
 
     return new Elide(new ElideSettingsBuilder(hibernateStore)
       .withJsonApiMapper(new JsonApiMapper(entityDictionary, objectMapper))
-      .withAuditLogger(new Slf4jLogger())
+      .withAuditLogger(new ExtendedAuditLogger())
       .withEntityDictionary(entityDictionary)
       .withJoinFilterDialect(rsqlFilterDialect)
       .withSubqueryFilterDialect(rsqlFilterDialect)

--- a/src/main/java/com/faforever/api/data/domain/Ladder1v1Map.java
+++ b/src/main/java/com/faforever/api/data/domain/Ladder1v1Map.java
@@ -4,6 +4,7 @@ import com.faforever.api.data.checks.permission.HasLadder1v1Update;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.UpdatePermission;
 import lombok.Setter;
 import org.hibernate.annotations.Immutable;
 
@@ -36,6 +37,7 @@ public class Ladder1v1Map {
 
   @OneToOne
   @JoinColumn(name = "idmap")
+  @UpdatePermission(expression = HasLadder1v1Update.EXPRESSION)
   public MapVersion getMapVersion() {
     return mapVersion;
   }

--- a/src/main/java/com/faforever/api/data/domain/Ladder1v1Map.java
+++ b/src/main/java/com/faforever/api/data/domain/Ladder1v1Map.java
@@ -1,6 +1,8 @@
 package com.faforever.api.data.domain;
 
 import com.faforever.api.data.checks.permission.HasLadder1v1Update;
+import com.yahoo.elide.annotation.Audit;
+import com.yahoo.elide.annotation.Audit.Action;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
@@ -24,6 +26,8 @@ import javax.persistence.Table;
 @Table(name = "ladder_map")
 @Include(rootLevel = true, type = "ladder1v1Map")
 @Immutable
+@Audit(action = Action.CREATE, logStatement = "Added map `{0}` with version `{1}` to the ladder pool", logExpressions = {"${ladder1v1Map.mapVersion.map.displayName}", "${ladder1v1Map.mapVersion.version}"})
+@Audit(action = Action.DELETE, logStatement = "Removed map `{0}` with version `{1}` from the ladder pool", logExpressions = {"${ladder1v1Map.mapVersion.map.displayName}", "${ladder1v1Map.mapVersion.version}"})
 public class Ladder1v1Map {
   private int id;
   private MapVersion mapVersion;

--- a/src/main/java/com/faforever/api/data/domain/LegacyAccessLevel.java
+++ b/src/main/java/com/faforever/api/data/domain/LegacyAccessLevel.java
@@ -4,6 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 
+import java.util.stream.Stream;
+
+/**
+ * @deprecated AccessLevel are going to be replaced with role based security
+ */
 @Getter
 @AllArgsConstructor
 @Deprecated
@@ -15,13 +20,10 @@ public enum LegacyAccessLevel implements GrantedAuthority {
   private final int code;
 
   public static LegacyAccessLevel fromCode(int code) {
-    for (LegacyAccessLevel level : LegacyAccessLevel.values()) {
-      if (level.code == code) {
-        return level;
-      }
-    }
-
-    throw new IllegalArgumentException(String.format("Code '%s' is unknown", code));
+    return Stream.of(LegacyAccessLevel.values())
+      .filter(level -> level.code == code)
+      .findFirst()
+      .orElseThrow(() -> new IllegalArgumentException(String.format("Code '%s' is unknown", code)));
   }
 
   @Override

--- a/src/main/java/com/faforever/api/data/domain/LegacyAccessLevel.java
+++ b/src/main/java/com/faforever/api/data/domain/LegacyAccessLevel.java
@@ -1,0 +1,31 @@
+package com.faforever.api.data.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+@AllArgsConstructor
+@Deprecated
+public enum LegacyAccessLevel implements GrantedAuthority {
+  ROLE_USER(0),
+  ROLE_MODERATOR(1),
+  ROLE_ADMINISTRATOR(2);
+
+  private final int code;
+
+  public static LegacyAccessLevel fromCode(int code) {
+    for (LegacyAccessLevel level : LegacyAccessLevel.values()) {
+      if (level.code == code) {
+        return level;
+      }
+    }
+
+    throw new IllegalArgumentException(String.format("Code '%s' is unknown", code));
+  }
+
+  @Override
+  public String getAuthority() {
+    return this.name();
+  }
+}

--- a/src/main/java/com/faforever/api/data/domain/LobbyGroup.java
+++ b/src/main/java/com/faforever/api/data/domain/LobbyGroup.java
@@ -11,6 +11,9 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+/**
+ * @deprecated LobbyGroups are supposed to be replaced with role based security
+ */
 @Entity
 @Table(name = "lobby_admin")
 @Setter

--- a/src/main/java/com/faforever/api/data/domain/LobbyGroup.java
+++ b/src/main/java/com/faforever/api/data/domain/LobbyGroup.java
@@ -1,0 +1,41 @@
+package com.faforever.api.data.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "lobby_admin")
+@Setter
+@Deprecated
+@NoArgsConstructor
+@AllArgsConstructor
+public class LobbyGroup {
+  private int userId;
+  private int accessLevel;
+  private User user;
+
+  @Column(name = "\"group\"")
+  public int getAccessLevel() {
+    return accessLevel;
+  }
+
+  @Id
+  @Column(name = "user_id")
+  public int getUserId() {
+    return userId;
+  }
+
+  @OneToOne
+  @JoinColumn(name = "user_id")
+  public User getUser() {
+    return user;
+  }
+}

--- a/src/main/java/com/faforever/api/data/domain/MapVersion.java
+++ b/src/main/java/com/faforever/api/data/domain/MapVersion.java
@@ -1,5 +1,6 @@
 package com.faforever.api.data.domain;
 
+import com.faforever.api.data.checks.permission.HasLadder1v1Update;
 import com.faforever.api.data.listeners.MapVersionEnricher;
 import com.yahoo.elide.annotation.ComputedAttribute;
 import com.yahoo.elide.annotation.Include;
@@ -148,6 +149,7 @@ public class MapVersion extends AbstractEntity {
   }
 
   @OneToOne(mappedBy = "mapVersion", cascade = CascadeType.ALL, orphanRemoval = true)
+  @UpdatePermission(expression = HasLadder1v1Update.EXPRESSION)
   public Ladder1v1Map getLadder1v1Map() {
     return ladder1v1Map;
   }

--- a/src/main/java/com/faforever/api/data/domain/User.java
+++ b/src/main/java/com/faforever/api/data/domain/User.java
@@ -4,6 +4,7 @@ import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
@@ -12,9 +13,15 @@ import javax.persistence.Table;
 public class User extends Login {
 
   private String password;
-  
+  private LobbyGroup lobbyGroup;
+
   @Column(name = "password")
   public String getPassword() {
     return password;
+  }
+
+  @OneToOne(mappedBy = "user")
+  public LobbyGroup getLobbyGroup() {
+    return lobbyGroup;
   }
 }

--- a/src/main/java/com/faforever/api/security/ExtendedAuditLogger.java
+++ b/src/main/java/com/faforever/api/security/ExtendedAuditLogger.java
@@ -1,0 +1,35 @@
+package com.faforever.api.security;
+
+import com.yahoo.elide.audit.AuditLogger;
+import com.yahoo.elide.audit.LogMessage;
+import com.yahoo.elide.core.RequestScope;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+
+@Slf4j
+public class ExtendedAuditLogger extends AuditLogger {
+  @Override
+  public void commit(RequestScope requestScope) throws IOException {
+    Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    String user;
+
+    if (principal instanceof FafUserDetails) {
+      FafUserDetails fafUserDetails = (FafUserDetails) principal;
+      user = MessageFormat.format("'{0}' with id '{1}'", fafUserDetails.getUsername(), fafUserDetails.getId());
+    } else {
+      user = principal.toString();
+    }
+
+    try {
+      for (LogMessage message : messages.get()) {
+        String extendedMessage = MessageFormat.format("{0} [invoked by {1}]", message.getMessage(), user);
+        log.debug(extendedMessage);
+      }
+    } finally {
+      messages.get().clear();
+    }
+  }
+}

--- a/src/main/java/com/faforever/api/security/FafUserDetails.java
+++ b/src/main/java/com/faforever/api/security/FafUserDetails.java
@@ -1,22 +1,19 @@
 package com.faforever.api.security;
 
+import com.faforever.api.data.domain.LegacyAccessLevel;
 import com.faforever.api.data.domain.User;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.Collection;
-
-import static java.util.Collections.singletonList;
 
 @Getter
 public class FafUserDetails extends org.springframework.security.core.userdetails.User {
 
   private final int id;
 
-  public FafUserDetails(User user) {
-    // TODO implement lobby_admin #81
-    this(user.getId(), user.getLogin(), user.getPassword(), !user.isGlobalBanned(), singletonList(new SimpleGrantedAuthority("ROLE_USER")));
+  public FafUserDetails(User user, Collection<? extends GrantedAuthority> authorities) {
+    this(user.getId(), user.getLogin(), user.getPassword(), !user.isGlobalBanned(), authorities);
   }
 
   public FafUserDetails(int id, String username, String password, boolean accountNonLocked, Collection<? extends GrantedAuthority> authorities) {
@@ -24,9 +21,18 @@ public class FafUserDetails extends org.springframework.security.core.userdetail
     this.id = id;
   }
 
-
   public boolean hasPermission(String permission) {
-    // TODO: implement permission system #81
+    Collection<GrantedAuthority> authorities = this.getAuthorities();
+
+    if (authorities.contains(LegacyAccessLevel.ROLE_ADMINISTRATOR)) {
+      return true;
+    }
+
+    if (authorities.contains(LegacyAccessLevel.ROLE_MODERATOR)) {
+      // We have no admin-only permissions yet
+      return true;
+    }
+
     return false;
   }
 }

--- a/src/main/java/com/faforever/api/security/FafUserDetailsService.java
+++ b/src/main/java/com/faforever/api/security/FafUserDetailsService.java
@@ -1,13 +1,16 @@
 package com.faforever.api.security;
 
+import com.faforever.api.data.domain.LegacyAccessLevel;
 import com.faforever.api.data.domain.User;
 import com.faforever.api.user.UserRepository;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
 
 /**
  * Adapter between Spring's {@link UserDetailsService} and FAF's {@code login} table.
@@ -25,8 +28,13 @@ public class FafUserDetailsService implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
     User user = userRepository.findOneByLoginIgnoreCase(username)
-      .orElseThrow(() -> new UsernameNotFoundException("User could not be found: " + username));
+    .orElseThrow(() -> new UsernameNotFoundException("User could not be found: " + username));
 
-    return new FafUserDetails(user);
+ArrayList<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(LegacyAccessLevel.ROLE_USER);
+
+    if (user.getLobbyGroup() != null) {
+      authorities.add(LegacyAccessLevel.fromCode(user.getLobbyGroup().getAccessLevel()));
+    }    return new FafUserDetails(user, authorities);
   }
 }

--- a/src/main/java/com/faforever/api/security/FafUserDetailsService.java
+++ b/src/main/java/com/faforever/api/security/FafUserDetailsService.java
@@ -28,13 +28,14 @@ public class FafUserDetailsService implements UserDetailsService {
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
     User user = userRepository.findOneByLoginIgnoreCase(username)
-    .orElseThrow(() -> new UsernameNotFoundException("User could not be found: " + username));
+      .orElseThrow(() -> new UsernameNotFoundException("User could not be found: " + username));
 
-ArrayList<GrantedAuthority> authorities = new ArrayList<>();
+    ArrayList<GrantedAuthority> authorities = new ArrayList<>();
     authorities.add(LegacyAccessLevel.ROLE_USER);
 
     if (user.getLobbyGroup() != null) {
       authorities.add(LegacyAccessLevel.fromCode(user.getLobbyGroup().getAccessLevel()));
-    }    return new FafUserDetails(user, authorities);
+    }
+    return new FafUserDetails(user, authorities);
   }
 }

--- a/src/main/java/com/faforever/api/security/OAuthClientDetails.java
+++ b/src/main/java/com/faforever/api/security/OAuthClientDetails.java
@@ -12,10 +12,10 @@ public class OAuthClientDetails extends BaseClientDetails {
   public OAuthClientDetails(OAuthClient oAuthClient) {
     super(oAuthClient.getId(),
       null,
-      oAuthClient.getDefaultScope().replace(' ', ','),
+      oAuthClient.getDefaultScope().replace(' ', ','), // stay compatible with Flask API
       "authorization_code,refresh_token,implicit,password,client_credentials",
       null,
-      oAuthClient.getRedirectUris());
+      oAuthClient.getRedirectUris().replace(' ', ',')); // stay compatible with Flask API
     setClientSecret(oAuthClient.getClientSecret());
   }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,4 +1,20 @@
 <configuration>
   <include resource="org/springframework/boot/logging/logback/base.xml"/>
   <jmxConfigurator/>
+
+  <!--Daily rolling file appender -->
+  <appender name="AUDIT" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <File>${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/audit.log</File>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <FileNamePattern>audit.%d{yyyy-MM-dd}.log</FileNamePattern>
+    </rollingPolicy>
+
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>%d - %msg%n</Pattern>
+    </layout>
+  </appender>
+
+  <logger name="com.faforever.api.security.ExtendedAuditLogger">
+    <appender-ref ref="AUDIT"/>
+  </logger>
 </configuration>

--- a/src/test/java/com/faforever/api/security/OAuthClientDetailsServiceTest.java
+++ b/src/test/java/com/faforever/api/security/OAuthClientDetailsServiceTest.java
@@ -30,7 +30,7 @@ public class OAuthClientDetailsServiceTest {
 
   @Test
   public void loadClientByClientId() throws Exception {
-    when(oAuthClientRepository.findOne("123")).thenReturn(new OAuthClient().setDefaultScope(""));
+    when(oAuthClientRepository.findOne("123")).thenReturn(new OAuthClient().setDefaultScope("").setRedirectUris(""));
 
     ClientDetails result = instance.loadClientByClientId("123");
 


### PR DESCRIPTION
This PR adds the permission system based on the existing `lobby_admin` table groups.
As a first reference I have prepared the `ladder1v1Map` entity for changing by faf moderators.
It uses an enhanced audit logger. This could be easily extended to write to file system, but the parameters are unclear to me.

Example logging:
```
c.f.api.security.ExtendedAuditLogger     : Removed map `SCMP_001` with version `1` from the ladder pool [invoked by user `Dostya` with id `2`]
c.f.api.security.ExtendedAuditLogger     : Added map `SCMP_001` with version `1` to the ladder pool [invoked by user `Dostya` with id `2`]
```

Any advice on how to add tests to this are welcome.