### PR TITLE
Fixes #220

### DIFF
--- a/src/main/java/com/faforever/api/featuredmods/LegacyFeaturedModFileRepository.java
+++ b/src/main/java/com/faforever/api/featuredmods/LegacyFeaturedModFileRepository.java
@@ -48,7 +48,7 @@ public class LegacyFeaturedModFileRepository implements Repository<FeaturedModFi
         "  ) latest" +
         "    ON file.fileId = latest.fileId" +
         "       AND file.version = latest.version" +
-        "  LEFT JOIN updates_%1$s b" +
+        "  INNER JOIN updates_%1$s b" +
         "    ON b.id = file.fileId;", innerModName, (version == null ? "" : "WHERE version <= :version")), FeaturedModFile.class);
 
     if (version != null) {


### PR DESCRIPTION
We have records in updates_nomads_files without corresponding recods in updates_nomads. According to CookieNoob these files are deprecated today. Moving to inner join will prevent the NPE, but may cause issues in replay compatibility.